### PR TITLE
Do a proper script execution via #!/usr/bin/env

### DIFF
--- a/sample_head.sh
+++ b/sample_head.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Source the optparse.bash file ---------------------------------------------------
 source optparse.bash


### PR DESCRIPTION
The invocation of a bash script with an absolute path to bash can cause problems on systems with a non-standard non-standard file system layouts.
To overcome this issue, use '#!/usr/bin/env'.
Good bash best practice source: http://andreinc.net/2011/09/04/bash-scripting-best-practice/
