### PR TITLE
Script breaks when using bash's nounset option

### DIFF
--- a/optparse.bash
+++ b/optparse.bash
@@ -19,6 +19,10 @@ function optparse.define(){
         if [ $# -lt 3 ]; then
                 optparse.throw_error "optparse.define <short> <long> <variable> [<desc>] [<default>] [<value>]"
         fi
+
+        # Initialize all local variables. This is needed for set -o nounset
+        local short="" shortname="" long="" longname="" desc="" default="" variable="" val="";
+
         for option_id in $( seq 1 $# ) ; do
                 local option="$( eval "echo \$$option_id")"
                 local key="$( echo $option | awk -F "=" '{print $1}' )";
@@ -64,6 +68,8 @@ function optparse.define(){
         optparse_contractions="${optparse_contractions}#NL#TB#TB${long})#NL#TB#TB#TBparams=\"\$params ${short}\";;"
         if [ "$default" != "" ]; then
                 optparse_defaults="${optparse_defaults}#NL${variable}=${default}"
+        else
+                optparse_defaults="${optparse_defaults}#NL${variable}=\"\""
         fi
         optparse_arguments_string="${optparse_arguments_string}${shortname}"
         if [ "$val" = "\$OPTARG" ]; then


### PR DESCRIPTION
Optparse breaks when ```set -o nounset``` is enabled.  This option makes bash generate an error when an uninitialized variable is encountered. Having this option on is generally good practice, kinda like strict mode, and is easy to fix. 

## Example code

Create an option with no default, turn on set -o nounset, and don't specify a value for argument. 
```bash
#!/usr/bin/env bash
set -o nounset
source "optparse.bash"
optparse.define short=i long=input desc="The input file. No default" variable=INPUT value=""
source $(optparse.build);
```

Now run the script with no arguments:
```bash
$ ./test.sh
optparse.bash: line 77: default: unbound variable
```

## Expected Result

Should not throw an error

## Cause

Local variables in the optparse.build parser loop are not declared. So since no 'default' attribute was given in optparse.define, it's uninitialized when we check for it later. 

Also when generating $optparse_defaults, arguments with no default specified should be declared empty. 

## Fix

Easy fix, just initialize all the local variables in optparse.define, prior to the parsing loop. Also in $optparse_defaults, when $default is empty, declare an empty variable. 

#### Above for loop

```bash
+
+ # Initialize all local variables. This is needed for set -o nounset
+ local short="" shortname="" long="" longname="" desc="" default="" variable="" val="";
+
  for option_id in $( seq 1 $# ) ; do
```

#### While generating $optparse_defaults

```bash
  if [ "$default" != "" ]; then
    optparse_defaults="${optparse_defaults}#NL${variable}=${default}"
+ else
+   optparse_defaults="${optparse_defaults}#NL${variable}=\"\""
```

## Final Thoughts

I've got a pull request coming your way to fix this too. 

This is a *really* easy bug fix for an issue that violates best practices for bash scripting. I hope you'll accept it in a timely manner.  Thanks.

