### PR TITLE
optparse breaks when spaces or special characters are in default values

### DIFF
--- a/optparse.bash
+++ b/optparse.bash
@@ -63,7 +63,10 @@ function optparse.define(){
         fi
         optparse_contractions="${optparse_contractions}#NL#TB#TB${long})#NL#TB#TB#TBparams=\"\$params ${short}\";;"
         if [ "$default" != "" ]; then
-                optparse_defaults="${optparse_defaults}#NL${variable}=${default}"
+                default=${default//\'/\'\\\'\'};
+                optparse_defaults="${optparse_defaults}#NL${variable}='${default}'"
+        else
+                optparse_defaults="${optparse_defaults}#NL${variable}=''"
         fi
         optparse_arguments_string="${optparse_arguments_string}${shortname}"
         if [ "$val" = "\$OPTARG" ]; then


### PR DESCRIPTION
Error occurs when a space is in argument default values (or passed from command line too, I believe). This is because the value assignment is not quoted at all in the generated tmp file.   

Also breaks when special characters (such as a single quote, double quote, any bash langauge specials) are in default values or passed. 

#### Example code

```bash
#!/usr/bin/env bash
source "optparse.bash"
optparse.define short=d long=default-value-with-spaces desc="An argument which has spaces in it's default value" variable=DEFAULT_WITH_SPACES default="default value with spaces"
optparse.define short=s long=default-value-with-specials desc="An argument with a few special characters in it. A single quote should be handled ok" variable=DEFAULT_WITH_SPECIALS default="this is ' the !@#$%^&*( \${P\} special values" 
```

#### Output

```bash
$ ./test.sh
/tmp/optparse-19676.tmp: line 44: value: command not found
/tmp/optparse-19676.tmp: line 45: unexpected EOF while looking for matching `''
/tmp/optparse-19676.tmp: line 68: syntax error: unexpected end of file
```

#### Expected result

Should handle spaces & special characters gracefully, without throwing an error. 

#### Fix

Easy fix, wrap assignment in quotes, and escape any quotes in the input. This fixes **most** special character use cases, better than nothing...   

Pull request is on the way.


