### PR TITLE
optparse.bash: use `mktemp -t` to safely create temp file

### DIFF
--- a/optparse.bash
+++ b/optparse.bash
@@ -96,7 +96,7 @@ function optparse.define(){
 
 # -----------------------------------------------------------------------------------------------------------------------------
 function optparse.build(){
-        local build_file="/tmp/optparse-${RANDOM}.tmp"
+        local build_file="$(mktemp -t "optparse-XXXXXX.tmp")"
 
         # Building getopts header here
 


### PR DESCRIPTION
* Use `local build_file="$(mktemp -t "optparse-XXXXXX.tmp")"`
  to create the temp file and to send back the file path

* This is similar to
  ```bash
  local build_file=${TMPDIR:-/tmp}/optparse-$RANDOM.tmp
  touch $build_file
  chmod 600 $build_file
  ```
  but avoids some vulnerabilities.