### PR TITLE
Tempfile-free evaluation by `optparse.compose` (fullly backward-compatible)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,21 @@ optparse.define short=v long=verbose desc="Set flag for verbose mode" variable=v
 ```
 
 ### 2. Evaluate your arguments
-The `optparse.build` function creates a temporary header script based on the provided argument definitions. Simply source the file the function returns, to parse the arguments.
+The `optparse.compose` function prints out the header content based on the provided argument definitions. Simply evaluate the result to parse the arguments.
+
+```bash
+eval "$(optparse.compose)"
+```
+
+If you don't want to have `eval` in your script, source it like:
+
+```bash
+source <<( optparse.compose )
+```
+
+To keep backward compatibility, the `optparse.build` function creates a temporary header script containing the result printed by `optparse.compose`, plus a command to delete itself after sourcing.
+
+Previous scripts source the file the function returns to parse the arguments.
 
 ```bash
 source $( optparse.build )

--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ A wrapper that provides a clean and easy way to parse arguments to your BASH scr
 ##### See `sample_head.sh` for a demonstration of optparse
 ### 1. Define your arguments
 
-Each argument to the script is defined with `optparse.define`, which specifies the option names, a short description, the variable it sets and the default value (if any). 
+Each argument to the script is defined with `optparse.define`, which specifies the option names, a short description, the variable it sets and the default value (if any).
 
 ```bash
 optparse.define short=f long=file desc="The input file" variable=filename
 ```
 
-Flags are defined in exactly the same way, but with an extra parameter `value` that is assigned to the variable. 
+Flags are defined in exactly the same way, but with an extra parameter `value` that is assigned to the variable.
 
 ```bash
 optparse.define short=v long=verbose desc="Set flag for verbose mode" variable=verbose_mode value=true default=false
-```    
+```
 
 ### 2. Evaluate your arguments
 The `optparse.build` function creates a temporary header script based on the provided argument definitions. Simply source the file the function returns, to parse the arguments.
@@ -35,16 +35,16 @@ source $( optparse.build )
 
 #### That's it!
 The script can now make use of the variables. Running the script (without any arguments) should give you a neat usage description.
-    
+
     usage: ./script.sh [OPTIONS]
-    
+
     OPTIONS:
-    
+
         -f --file  :  The input file
     	-v --verbose  :  Set flag for verbose mode
-    
+
     	-? --help  :  usage
-        
+
 ## Supported definition parameters
 All definition parameters for `optparse.define` are provided as `key=value` pairs, seperated by an `=` sign.
 #### `short`
@@ -62,10 +62,10 @@ the default value to set the variable to if argument not specified
 
 ## Installation
 1. Download/clone `optparse.bash`
-2. Add 
+2. Add
 
-```bash    
-`source /path/to/optparse.bash` 
+```bash
+`source /path/to/optparse.bash`
 ```
 to `~/.bashrc`
 

--- a/optparse.bash
+++ b/optparse.bash
@@ -101,7 +101,7 @@ function optparse.compose(){
                 UNSET_GLOBAL=false
         fi
         # Composing getopts header
-        cat << EOF | sed 's/#NL/\n/g' | sed 's/#TB/\t/g'
+        cat << EOF | sed 's/#NL/\n/g' | sed 's/#TB/\t/g' | sed 's/[ \t]+$//'
 function usage(){
 cat << XXX
 usage: \$0 [OPTIONS]

--- a/optparse.bash
+++ b/optparse.bash
@@ -95,13 +95,13 @@ function optparse.define(){
 }
 
 # -----------------------------------------------------------------------------------------------------------------------------
-function optparse.build(){
-        local build_file="$(mktemp -t "optparse-XXXXXX.tmp")"
-
-        # Building getopts header here
-
-        # Function usage
-        cat << EOF > $build_file
+function optparse.compose(){
+        local UNSET_GLOBAL=true
+        if [ "$#" -ge 0 ] && [ "$1" == "--no-unset" ]; then
+                UNSET_GLOBAL=false
+        fi
+        # Composing getopts header
+        cat << EOF | sed 's/#NL/\n/g' | sed 's/#TB/\t/g'
 function usage(){
 cat << XXX
 usage: \$0 [OPTIONS]
@@ -154,23 +154,27 @@ while getopts "$optparse_arguments_string" option; do
         esac
 done
 
-# Clean up after self
-rm $build_file
-
 EOF
+        if $UNSET_GLOBAL; then
+                # Unset global variables
+                unset optparse_usage
+                unset optparse_process
+                unset optparse_arguments_string
+                unset optparse_defaults
+                unset optparse_contractions
+        fi
+}
 
-        local -A o=( ['#NL']='\n' ['#TB']='\t' )
+# -----------------------------------------------------------------------------------------------------------------------------
+# Kept for backward compatibility (2022-01-01)
+function optparse.build(){
+        local build_file="$(mktemp -t "optparse-XXXXXX.tmp")"
 
-        for i in "${!o[@]}"; do
-                sed -i "s/${i}/${o[$i]}/g" $build_file
-        done
+        # Writing configurations into the getopts header
+        optparse.compose > "$build_file"
 
-        # Unset global variables
-        unset optparse_usage
-        unset optparse_process
-        unset optparse_arguments_string
-        unset optparse_defaults
-        unset optparse_contractions
+        # Clean up after self
+        echo 'rm $build_file' >> "$build_file"
 
         # Return file name to parent
         echo "$build_file"

--- a/sample_head.sh
+++ b/sample_head.sh
@@ -17,7 +17,7 @@ fi
 
 # Display arguments
 if [ "$verbose_mode" = "true" ]; then
-	echo "Verbose mode ON"	
+	echo "Verbose mode ON"
 	echo "FILE  : $file"
 	echo "OUTPUT: $output"
 	echo "LINES : $lines"
@@ -36,4 +36,4 @@ cat $file | head -n $lines > $output
 if [ "$verbose_mode" = "true" ]; then echo "Done."; fi
 
 exit 0
-	
+

--- a/sample_head_legacy.sh
+++ b/sample_head_legacy.sh
@@ -8,7 +8,7 @@ optparse.define short=o long=output desc="The output file" variable=output defau
 optparse.define short=l long=lines desc="The number of lines to head (default:5)" variable=lines default=5
 optparse.define short=v long=verbose desc="Flag to set verbose mode on" variable=verbose_mode value=true default=false
 # Source the output file ----------------------------------------------------------
-eval "$(optparse.compose)"
+source $( optparse.build )
 
 if [ "$file" == "" ]; then
 	echo "ERROR: Please provide a file"


### PR DESCRIPTION
The previous API requires a temporary file to be created and sourced, which might be a problem in restricted environments where accessing to temporary directories are restricted or where file IO is relatively expensive. Besides, the temporary files are often left undeleted despite the `rm` line being sourced. 

This PR proposes a way to print out the configuration headers through a new function `optparse.compose`, which can be evaluated (`eval "$(optparse.compose)"`) or sourced (`. <<(optparse.compose)`) in the user scripts to include the configurations without the need of temporary files.

The changes are a backward-compatible, as `optparse.build` now write to the temporary file the result of `optparse.compose` plus the line `remove $tempfile`.

This PR also include some house-keeping such as removing trailing white spaces and tabs from the generated result, `sample_head.sh` and `README.md`.